### PR TITLE
Add support for permanent failure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ application.
 Tasks are controlled by a state machine depicted in the following picture.
 
 ```
-  execute({Mod, Fun, Args})
+  execute(MFA = {Mod, Fun, Args})
              |
              |
              v
@@ -21,11 +21,14 @@ node down         spawn worker
         |     exception           retry
         |         |                 |
         |         `--->[ Failed ]---'
-     success               |
-        |         max retries exceeded
-        |                  |
-        |                  v
-        |         {error, failed_max_retries_times}
+     success           |        |
+        |        max retries  MFA called
+        |         exceeded    throw(gascheduler_permanent_failure)
+        |              |        |
+        |              v        |
+        |  {error, max_retries} |
+        |                       v
+        |                   {error, permanent_failure}
         v
 {ok, Result = apply(Mod, Fun, Args)}
 ```

--- a/src/gascheduler.erl
+++ b/src/gascheduler.erl
@@ -264,6 +264,12 @@ log_retry(Type, Error, MFA) ->
                              [Type, Error, MFA]).
 
 
+-spec log_permanent_failure(any(), any(), mfa()) -> ok.
+log_permanent_failure(Type, Error, MFA) ->
+    error_logger:error_msg("gascheduler: caught ~p:~p in ~p -> giving up, permanent failure",
+                            [Type, Error, MFA]).
+
+
 %% Executes MFA MaxRetries times
 -spec execute_do(mfa(), non_neg_integer()) -> result().
 execute_do(_MFA, 0) ->
@@ -271,16 +277,24 @@ execute_do(_MFA, 0) ->
 execute_do(MFA = {Mod, Fun, Args}, infinity) ->
     try
         {ok, apply(Mod, Fun, Args)}
-    catch Type:Error ->
-        log_retry(Type, Error, MFA),
-        execute_do(MFA, infinity)
+    catch
+        throw:gascheduler_permanent_failure ->
+            log_permanent_failure(throw, gascheduler_permanent_failure, MFA),
+            {error, permanent_failure};
+        Type:Error ->
+            log_retry(Type, Error, MFA),
+            execute_do(MFA, infinity)
     end;
 execute_do(MFA = {Mod, Fun, Args}, MaxRetries) ->
     try
         {ok, apply(Mod, Fun, Args)}
-    catch Type:Error ->
-        log_retry(Type, Error, MFA),
-        execute_do(MFA, MaxRetries - 1)
+    catch
+        throw:gascheduler_permanent_failure ->
+            log_permanent_failure(throw, gascheduler_permanent_failure, MFA),
+            {error, permanent_failure};
+        Type:Error ->
+            log_retry(Type, Error, MFA),
+            execute_do(MFA, MaxRetries - 1)
     end.
 
 -spec worker_fun(pid(), mfa(), max_retries()) -> ok.


### PR DESCRIPTION
A function being executed can indicate permanent failure by
throw(gascheduler_permanent_failure). This stops all execution and returns
{gascheduler, {error, permanent_failure}, Node, MFA} to the client.
