### PR TITLE
Print stack trace and delay on exceptions.

### DIFF
--- a/src/gascheduler.erl
+++ b/src/gascheduler.erl
@@ -288,7 +288,9 @@ execute_do(MFA = {Mod, Fun, Args}, infinity) ->
             log_permanent_failure(throw, gascheduler_permanent_failure, MFA),
             {error, permanent_failure};
         Type:Error ->
+            error_logger:error_msg("~p", [erlang:get_stacktrace()]),
             log_retry(Type, Error, MFA),
+            timer:sleep(1000),
             execute_do(MFA, infinity)
     end;
 execute_do(MFA = {Mod, Fun, Args}, MaxRetries) ->


### PR DESCRIPTION
Gascheduler immediately retries when a worker throws an exception. This
can overload the Erlang VM. So a sleep of 1 second was added. It also
did not previously print the stack trace either.
