### PR TITLE
Add start_link/4 to start a scheduler without registering a name for it

### DIFF
--- a/src/gascheduler.erl
+++ b/src/gascheduler.erl
@@ -203,7 +203,10 @@ handle_cast(tick, State = #state{ticks = Ticks, pending = Pending}) ->
 
 handle_cast({Result, Worker, MFA}, State = #state{running = Running,
                                                   client = Client}) ->
-    {registered_name, Name} = process_info(self(), registered_name),
+    Name = case process_info(self(), registered_name) of
+               {registered_name, N} -> N;
+               _                    -> self() %% no name, just use pid
+           end,
     Client ! {Name, Result, node(Worker), MFA},
     {noreply, State#state{running = remove_worker(Worker, Running)}};
 

--- a/src/gascheduler.erl
+++ b/src/gascheduler.erl
@@ -6,6 +6,7 @@
 
 %% API
 -export([start_link/5,
+         start_link/4,
          stop/1,
          execute/2,
          add_worker_node/2,
@@ -78,6 +79,12 @@
           -> {ok, pid()}.
 start_link(Name, Nodes, Client, MaxWorkers, MaxRetries) ->
     gen_server:start_link({local, Name}, ?MODULE,
+                           [Nodes, Client, MaxWorkers, MaxRetries], []).
+
+-spec start_link(worker_nodes(), client(), max_workers(), max_retries())
+          -> {ok, pid()}.
+start_link(Nodes, Client, MaxWorkers, MaxRetries) ->
+    gen_server:start_link(?MODULE,
                            [Nodes, Client, MaxWorkers, MaxRetries], []).
 
 -spec stop(atom()) -> ok.

--- a/test/gascheduler_test.erl
+++ b/test/gascheduler_test.erl
@@ -20,7 +20,8 @@ gascheduler_test_() ->
       {spawn, {timeout, 60,  ?_test(node_down())}},
       {spawn, {timeout, 60,  ?_test(unfinished())}},
       {spawn, {timeout, 60,  ?_test(permanent_failure())}},
-      {spawn, {timeout, 120, ?_test(exit_handling())}}
+      {spawn, {timeout, 120, ?_test(exit_handling())}},
+      {spawn, ?_test(unnamed_scheduler())}
     ]}.
 
 
@@ -378,6 +379,22 @@ exit_handling() ->
 
     %% make sure previous gascheduler processes it no longer running
     ?assertNot(is_process_alive(SchedulerPid)),
+
+    ok.
+
+%% Start a scheduler with no name
+%% Assert no name is registered for the pid of the scheduler
+unnamed_scheduler() ->
+    Client = self(),
+    Nodes = [node()],
+
+    {ok, Pid} = gascheduler:start_link(Nodes, Client, 1, 1),
+
+    %% See erlang:process_info/2 on why we get a list when there is no name
+    %% registered.
+    ?assertEqual([], process_info(Pid, registered_name)),
+
+    ok = gascheduler:stop(Pid),
 
     ok.
 


### PR DESCRIPTION
The pid returned can be used instead of a registered name in cases where a name does not make sense or would lead to name conflicts when running multiple schedulers at the same time.